### PR TITLE
173 add file type checking to inp file parser

### DIFF
--- a/src/js/parse-geometry.js
+++ b/src/js/parse-geometry.js
@@ -14,6 +14,7 @@ input.addEventListener('change', () => {
   const fileExt = filename.split('.').pop() // splits the string on '.' and returns the last array element, which will be the file extension/type
 
   if (fileExt !== 'inp') { // ensures that files are .inp files before attempting to parse them
+    alert('Geometry files must be in .inp format') // alerts the user if files are not .inp
     return
   }
 

--- a/src/js/parse-geometry.js
+++ b/src/js/parse-geometry.js
@@ -7,7 +7,7 @@ const elements = [[]]
 input.addEventListener('change', () => {
   const files = input.files
 
-  if (files.length === 0) return //check for empty files
+  if (files.length === 0) return // check for empty files
 
   const file = files[0]
   const filename = file.name

--- a/src/js/parse-geometry.js
+++ b/src/js/parse-geometry.js
@@ -1,17 +1,21 @@
 const input = document.getElementById('file1')
 
-// const submit = document.getElementById('submit') // Don't need this yet
-
 const nodes = [[]]
 const elements = [[]]
 
-// runs as soon as a user selects a file - needs some additional file-type safety
+// runs as soon as a user selects a file
 input.addEventListener('change', () => {
   const files = input.files
 
-  if (files.length === 0) return
+  if (files.length === 0) return //check for empty files
 
   const file = files[0]
+  const filename = file.name
+  const fileExt = filename.split('.').pop() // splits the string on '.' and returns the last array element, which will be the file extension/type
+
+  if (fileExt !== 'inp') { // ensures that files are .inp files before attempting to parse them
+    return
+  }
 
   const reader = new FileReader()
 


### PR DESCRIPTION
The Geometry file upload button will only accept and try to parse .inp files. If a file does not use the .inp extension, a message pops up for the user to let them know.