### PR TITLE
197 update element session data storage and naming conventions

### DIFF
--- a/src/js/parse-geometry.js
+++ b/src/js/parse-geometry.js
@@ -134,20 +134,17 @@ input.addEventListener('change', () => {
     console.log('ELEMENTS SESSION DATA' + '\n' + 'total elements: ' + length + '\n' + 'node 1, node 2, node 3, node 4' + '\n') // for testing
 
     while (length > 1) {
-      sessionStorage.setItem('element ' + index + 'node 1', elements[index][0])
-      // console.log(sessionStorage.getItem('element ' + index + 'node 1')) // for testing
+      sessionStorage.setItem('element ' + elements[index][0] + ' node 1', elements[index][1])
+      // console.log(sessionStorage.getItem('element ' + elements[index][0] + ' node 1')) // for testing
 
-      sessionStorage.setItem('element ' + index + 'node 2', elements[index][1])
-      // console.log(sessionStorage.getItem('element ' + index + 'node 2')) // for testing
+      sessionStorage.setItem('element ' + elements[index][0]  + ' node 2', elements[index][2])
+      // console.log(sessionStorage.getItem('element ' + elements[index][0] + ' node 2')) // for testing
 
-      sessionStorage.setItem('element ' + index + 'node 3', elements[index][2])
-      // console.log(sessionStorage.getItem('element ' + index + 'node 3')) // for testing
+      sessionStorage.setItem('element ' + elements[index][0] + ' node 3', elements[index][3])
+      // console.log(sessionStorage.getItem('element ' + elements[index][0] + ' node 3')) // for testing
 
-      sessionStorage.setItem('element ' + index + 'node 4', elements[index][3])
-      // console.log(sessionStorage.getItem('element ' + index + 'node 4')) // for testing
-
-      console.log(sessionStorage.getItem('element ' + index + 'node 1') + ' ' + sessionStorage.getItem('element ' + index + 'node 2') + ' ' + sessionStorage.getItem('element ' + index + 'node 3') + ' ' + sessionStorage.getItem('element ' + index + 'node 4')) // for testing
-
+      console.log(elements[index][0] + ' ' + sessionStorage.getItem('element ' + elements[index][0] + ' node 1') + ' ' + sessionStorage.getItem('element ' + elements[index][0] + ' node 2') + ' ' + sessionStorage.getItem('element ' + elements[index][0] + ' node 3')) // for testing
+      
       index++
       length--
     }

--- a/src/js/parse-geometry.js
+++ b/src/js/parse-geometry.js
@@ -131,7 +131,12 @@ input.addEventListener('change', () => {
 
     index = 0 // reset array index for element session storage
     length = elements.length // reset length to number of element in final element array
-    console.log('ELEMENTS SESSION DATA' + '\n' + 'total elements: ' + length + '\n' + 'node 1, node 2, node 3, node 4' + '\n') // for testing
+
+    sessionStorage.setItem('total elements', length) // store total number of elements in session data
+    sessionStorage.setItem('initial element number', elements[index][0]) // store initial element number in session data
+
+    console.log('ELEMENTS SESSION DATA' + '\n' + 'total elements: ' + sessionStorage.getItem('total elements') + '\n' + 'element number, node 1, node 2, node 3' + '\n') // for testing
+    console.log('starting element number: ' + sessionStorage.getItem('initial element number') + '\n') // for testing
 
     while (length > 1) {
       sessionStorage.setItem('element ' + elements[index][0] + ' node 1', elements[index][1])
@@ -144,7 +149,7 @@ input.addEventListener('change', () => {
       // console.log(sessionStorage.getItem('element ' + elements[index][0] + ' node 3')) // for testing
 
       console.log(elements[index][0] + ' ' + sessionStorage.getItem('element ' + elements[index][0] + ' node 1') + ' ' + sessionStorage.getItem('element ' + elements[index][0] + ' node 2') + ' ' + sessionStorage.getItem('element ' + elements[index][0] + ' node 3')) // for testing
-      
+
       index++
       length--
     }

--- a/src/js/parse-geometry.js
+++ b/src/js/parse-geometry.js
@@ -142,7 +142,7 @@ input.addEventListener('change', () => {
       sessionStorage.setItem('element ' + elements[index][0] + ' node 1', elements[index][1])
       // console.log(sessionStorage.getItem('element ' + elements[index][0] + ' node 1')) // for testing
 
-      sessionStorage.setItem('element ' + elements[index][0]  + ' node 2', elements[index][2])
+      sessionStorage.setItem('element ' + elements[index][0] + ' node 2', elements[index][2])
       // console.log(sessionStorage.getItem('element ' + elements[index][0] + ' node 2')) // for testing
 
       sessionStorage.setItem('element ' + elements[index][0] + ' node 3', elements[index][3])


### PR DESCRIPTION
We are now also storing the total number of elements and the first element number as session storage items as well, and the old naming conventions for the nodes that make up elements have been updated to reflect our better understanding of them. New naming conventions are:

'total elements'
'initial element number'
'element element# node 1'
'element element# node 2'
'element element# node 3'

The element# for accessing individual nodes in an element will change based on which element you want to access.