### PR TITLE
234 parser checks file name to determine tissue type

### DIFF
--- a/src/js/parse-geometry.js
+++ b/src/js/parse-geometry.js
@@ -1,6 +1,8 @@
 const input = document.getElementById('file1')
 let nodes = [[]]
 let elements = [[]]
+let isCart = false
+let isBone = false
 
 // runs as soon as a user selects a file
 input.addEventListener('change', () => {
@@ -25,6 +27,15 @@ input.addEventListener('change', () => {
     alert('Geometry files must be in .inp format') // alerts the user if files are not .inp
     return
   }
+
+  if (filename.toLowerCase().includes('cart')) { // makes filename case insensitive & checks for cartilage file naming convention
+    isCart = true
+  } else if (filename.toLowerCase().includes('bone')) { // makes filename case insensitive & checks for bone file naming convention
+    isBone = true
+  }
+
+  console.log('isCart = ' + isCart) // for testing
+  console.log('isBone = ' + isBone) // for testing
 
   const reader = new FileReader()
 

--- a/src/js/parse-geometry.js
+++ b/src/js/parse-geometry.js
@@ -32,6 +32,9 @@ input.addEventListener('change', () => {
     isCart = true
   } else if (filename.toLowerCase().includes('bone')) { // makes filename case insensitive & checks for bone file naming convention
     isBone = true
+  } else {
+    alert('File name does not specify whether it is a bone or cartilage file') // alerts the user if file does not follow expected file naming conventions
+    return
   }
 
   console.log('isCart = ' + isCart) // for testing

--- a/src/js/parse-geometry.js
+++ b/src/js/parse-geometry.js
@@ -17,6 +17,9 @@ input.addEventListener('change', () => {
   elements = [[]]
   sessionStorage.clear()
 
+  isCart = false
+  isBone = false
+
   if (files.length === 0) return // check for empty files
 
   const file = files[0]


### PR DESCRIPTION
Parser uses the expected file naming conventions to determine if it is reading a bone or cartilage file. Bone files should always have the string 'bone' in them and cartilage files should always have the string 'cart' in them. The check for these strings is case-insensitive.