### PR TITLE
Parser creates 8-node element array for cartilage files

### DIFF
--- a/src/js/parse-geometry.js
+++ b/src/js/parse-geometry.js
@@ -171,24 +171,34 @@ input.addEventListener('change', () => {
     console.log('ELEMENTS SESSION DATA' + '\n' + 'total elements: ' + sessionStorage.getItem('total elements') + '\n' + 'element number, node 1, node 2, node 3' + '\n') // for testing
     console.log('starting element number: ' + sessionStorage.getItem('initial element number') + '\n') // for testing
 
-    if (isBone) {
-      while (length >= 1) {
-        sessionStorage.setItem('element ' + elements[index][0] + ' node 1', elements[index][1])
-        // console.log(sessionStorage.getItem('element ' + elements[index][0] + ' node 1')) // for testing
+    while (length >= 1) {
+      sessionStorage.setItem('element ' + elements[index][0] + ' node 1', elements[index][1])
+      // console.log(sessionStorage.getItem('element ' + elements[index][0] + ' node 1')) // for testing
 
-        sessionStorage.setItem('element ' + elements[index][0] + ' node 2', elements[index][2])
-        // console.log(sessionStorage.getItem('element ' + elements[index][0] + ' node 2')) // for testing
+      sessionStorage.setItem('element ' + elements[index][0] + ' node 2', elements[index][2])
+      // console.log(sessionStorage.getItem('element ' + elements[index][0] + ' node 2')) // for testing
 
-        sessionStorage.setItem('element ' + elements[index][0] + ' node 3', elements[index][3])
-        // console.log(sessionStorage.getItem('element ' + elements[index][0] + ' node 3')) // for testing
+      sessionStorage.setItem('element ' + elements[index][0] + ' node 3', elements[index][3])
+      // console.log(sessionStorage.getItem('element ' + elements[index][0] + ' node 3')) // for testing
 
+      if (isBone) { // this test statement is only helpful for bone files
         console.log(elements[index][0] + ' ' + sessionStorage.getItem('element ' + elements[index][0] + ' node 1') + ' ' + sessionStorage.getItem('element ' + elements[index][0] + ' node 2') + ' ' + sessionStorage.getItem('element ' + elements[index][0] + ' node 3')) // for testing
+      } else if (isCart) { // only cartilage files have more than 3 nodes per element
+        sessionStorage.setItem('element ' + elements[index][0] + ' node 4', elements[index][4])
+  
+        sessionStorage.setItem('element ' + elements[index][0] + ' node 5', elements[index][5])
+  
+        sessionStorage.setItem('element ' + elements[index][0] + ' node 6', elements[index][6])
 
-        index++
-        length--
+        sessionStorage.setItem('element ' + elements[index][0] + ' node 7', elements[index][7])
+
+        sessionStorage.setItem('element ' + elements[index][0] + ' node 8', elements[index][8])
+
+        console.log(elements[index][0] + ' ' + sessionStorage.getItem('element ' + elements[index][0] + ' node 1') + ' ' + sessionStorage.getItem('element ' + elements[index][0] + ' node 2') + ' ' + sessionStorage.getItem('element ' + elements[index][0] + ' node 3') + ' ' + sessionStorage.getItem('element ' + elements[index][0] + ' node 4') + ' ' + sessionStorage.getItem('element ' + elements[index][0] + ' node 5') + ' ' + sessionStorage.getItem('element ' + elements[index][0] + ' node 6') + ' ' + sessionStorage.getItem('element ' + elements[index][0] + ' node 7') + ' ' + sessionStorage.getItem('element ' + elements[index][0] + ' node 8')) // for testing
       }
-    } else if (isCart) {
-      console.log('CARTILAGE FILE') // for testing
+        
+      index++
+      length--
     }
   }
   reader.onerror = (e) => alert(e.target.error.name)

--- a/src/js/parse-geometry.js
+++ b/src/js/parse-geometry.js
@@ -196,7 +196,7 @@ input.addEventListener('change', () => {
 
         console.log(elements[index][0] + ' ' + sessionStorage.getItem('element ' + elements[index][0] + ' node 1') + ' ' + sessionStorage.getItem('element ' + elements[index][0] + ' node 2') + ' ' + sessionStorage.getItem('element ' + elements[index][0] + ' node 3') + ' ' + sessionStorage.getItem('element ' + elements[index][0] + ' node 4') + ' ' + sessionStorage.getItem('element ' + elements[index][0] + ' node 5') + ' ' + sessionStorage.getItem('element ' + elements[index][0] + ' node 6') + ' ' + sessionStorage.getItem('element ' + elements[index][0] + ' node 7') + ' ' + sessionStorage.getItem('element ' + elements[index][0] + ' node 8')) // for testing
       }
-      
+
       index++
       length--
     }

--- a/src/js/parse-geometry.js
+++ b/src/js/parse-geometry.js
@@ -185,9 +185,9 @@ input.addEventListener('change', () => {
         console.log(elements[index][0] + ' ' + sessionStorage.getItem('element ' + elements[index][0] + ' node 1') + ' ' + sessionStorage.getItem('element ' + elements[index][0] + ' node 2') + ' ' + sessionStorage.getItem('element ' + elements[index][0] + ' node 3')) // for testing
       } else if (isCart) { // only cartilage files have more than 3 nodes per element
         sessionStorage.setItem('element ' + elements[index][0] + ' node 4', elements[index][4])
-  
+
         sessionStorage.setItem('element ' + elements[index][0] + ' node 5', elements[index][5])
-  
+
         sessionStorage.setItem('element ' + elements[index][0] + ' node 6', elements[index][6])
 
         sessionStorage.setItem('element ' + elements[index][0] + ' node 7', elements[index][7])
@@ -196,7 +196,7 @@ input.addEventListener('change', () => {
 
         console.log(elements[index][0] + ' ' + sessionStorage.getItem('element ' + elements[index][0] + ' node 1') + ' ' + sessionStorage.getItem('element ' + elements[index][0] + ' node 2') + ' ' + sessionStorage.getItem('element ' + elements[index][0] + ' node 3') + ' ' + sessionStorage.getItem('element ' + elements[index][0] + ' node 4') + ' ' + sessionStorage.getItem('element ' + elements[index][0] + ' node 5') + ' ' + sessionStorage.getItem('element ' + elements[index][0] + ' node 6') + ' ' + sessionStorage.getItem('element ' + elements[index][0] + ' node 7') + ' ' + sessionStorage.getItem('element ' + elements[index][0] + ' node 8')) // for testing
       }
-        
+      
       index++
       length--
     }


### PR DESCRIPTION
Each row of the elements array created by a cartilage .inp file is now length 9. Index 0 is the element number itself, and then indexes 1 through 8 are the nodes required to make a cartilage element. These elements can be drawn as cubes instead of the triangles for bone .inp files.

Naming conventions for accessing cartilage element session data are:

'total elements'
'initial element number'
'element element# node 1'
'element element# node 2'
'element element# node 3'
'element element# node 4'
'element element# node 5'
'element element# node 6'
'element element# node 7'
'element element# node 8'

The element# for accessing individual nodes in an element will change based on which element you want to access. It should always be index 0 of its row in the multidimensional elements array.