### PR TITLE
changed !== operator back to != in both dial js files

### DIFF
--- a/src/js/body-weight-dial.js
+++ b/src/js/body-weight-dial.js
@@ -63,8 +63,8 @@ function rotate2 (e) {
   // final calculations for the mouse position
   const result = Math.floor(parameterDial2(e) - 80)
 
-  // rotate the dial based on final calculation
-  if ((val2.value !== maxVal2) && (val2.value != 0)) { // eslint-disable-line, do not rotate further if value is at 0 or max
+  // rotate the dial based on final calculation - do not rotate further if value is at 0 or max
+  if ((val2.value !== maxVal2) && (val2.value != 0)) { // eslint-disable-line
     dial2.style.transform = 'rotate(' + result + 'deg)'
   }
 }

--- a/src/js/body-weight-dial.js
+++ b/src/js/body-weight-dial.js
@@ -64,7 +64,7 @@ function rotate2 (e) {
   const result = Math.floor(parameterDial2(e) - 80)
 
   // rotate the dial based on final calculation
-  if ((val2.value !== maxVal2) && (val2.value != 0)) { // do not rotate further if value is at 0 or max
+  if ((val2.value !== maxVal2) && (val2.value != 0)) { // eslint-disable-line, do not rotate further if value is at 0 or max
     dial2.style.transform = 'rotate(' + result + 'deg)'
   }
 }

--- a/src/js/body-weight-dial.js
+++ b/src/js/body-weight-dial.js
@@ -64,7 +64,7 @@ function rotate2 (e) {
   const result = Math.floor(parameterDial2(e) - 80)
 
   // rotate the dial based on final calculation
-  if ((val2.value !== maxVal2) && (val2.value !== 0)) { // do not rotate further if value is at 0 or max
+  if ((val2.value !== maxVal2) && (val2.value != 0)) { // do not rotate further if value is at 0 or max
     dial2.style.transform = 'rotate(' + result + 'deg)'
   }
 }

--- a/src/js/limb-alignment-dial.js
+++ b/src/js/limb-alignment-dial.js
@@ -70,8 +70,8 @@ function rotate1 (e) {
   // final calculations for the mouse position
   const result = Math.floor(parameterDial1(e) - 80)
 
-  // rotate the dial based on final calculation
-  if ((val1.value !== maxVal1) && (val1.value != 0)) { // eslint-disable-line, do not rotate further if value is at 0 or max. Line disabled because linter did not like '!=' operator
+  // rotate the dial based on final calculation - do not rotate further if value is at 0 or max
+  if ((val1.value !== maxVal1) && (val1.value != 0)) { // eslint-disable-line
     // console.log(val1.value) // for testing
     dial1.style.transform = 'rotate(' + result + 'deg)'
   }

--- a/src/js/limb-alignment-dial.js
+++ b/src/js/limb-alignment-dial.js
@@ -71,7 +71,7 @@ function rotate1 (e) {
   const result = Math.floor(parameterDial1(e) - 80)
 
   // rotate the dial based on final calculation
-  if ((val1.value !== maxVal1) && (val1.value != 0)) { // do not rotate further if value is at 0 or max
+  if ((val1.value !== maxVal1) && (val1.value != 0)) { // eslint-disable-line, do not rotate further if value is at 0 or max
     // console.log(val1.value) // for testing
     dial1.style.transform = 'rotate(' + result + 'deg)'
   }

--- a/src/js/limb-alignment-dial.js
+++ b/src/js/limb-alignment-dial.js
@@ -71,7 +71,7 @@ function rotate1 (e) {
   const result = Math.floor(parameterDial1(e) - 80)
 
   // rotate the dial based on final calculation
-  if ((val1.value !== maxVal1) && (val1.value !== 0)) { // do not rotate further if value is at 0 or max
+  if ((val1.value !== maxVal1) && (val1.value != 0)) { // do not rotate further if value is at 0 or max
     // console.log(val1.value) // for testing
     dial1.style.transform = 'rotate(' + result + 'deg)'
   }

--- a/src/js/limb-alignment-dial.js
+++ b/src/js/limb-alignment-dial.js
@@ -71,7 +71,7 @@ function rotate1 (e) {
   const result = Math.floor(parameterDial1(e) - 80)
 
   // rotate the dial based on final calculation
-  if ((val1.value !== maxVal1) && (val1.value != 0)) { // eslint-disable-line, do not rotate further if value is at 0 or max
+  if ((val1.value !== maxVal1) && (val1.value != 0)) { // eslint-disable-line, do not rotate further if value is at 0 or max. Line disabled because linter did not like '!=' operator
     // console.log(val1.value) // for testing
     dial1.style.transform = 'rotate(' + result + 'deg)'
   }


### PR DESCRIPTION
On line 74 of limb-alignment-dial.js and line 67 of body-weight-dial.js, the linter wanted me to use the '!==' operator instead of '!=' for both of the comparison statements. I made this fix, but for some reason, it broke the code only for the '!== 0' comparison. The code works again if '!= 0' is used, but it also has no issue with the '!== maxVal' comparison. I'm not quite sure why that's the case, but I would like to ignore the linter on this one and change the code back to using the '!=' operator for the '!= 0' comparison.