### PR TITLE
275 move + and - buttons below canvas

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -20,7 +20,7 @@
                             <th>Geometry File: <input type="file" class="choose-file" id="file1" accept=".inp"></th>
                         </tr>
                         <tr>
-                            <th>Results File: <input type="file" class="choose-file" id="file2" accept=".csv"></th>
+                            <th>&ensp;&emsp;Results File: <input type="file" class="choose-file" id="file2" accept=".csv"></th>
                         </tr> 
                     </table> 
                     <button class="draw-btn button" id="draw">Draw</button>  
@@ -32,6 +32,7 @@
         <div class="grid-item dial-1-container">
             <div class="dial-buttons dial-buttons-1">
                 <p>Limb Alignment (&deg;)</p>
+                <span class="dial-min-max">15</span><span class="dial-min-max-divider">&nbsp;|&nbsp;</span><span class="dial-min-max">0&nbsp;</span>
                 <div class="dial-shadow">
                     <div class="dial-container" id="limb-alignment">
                         <div class="dial"></div>
@@ -47,6 +48,7 @@
         <div class="grid-item dial-2-container">
             <div class="dial-buttons dial-buttons-2">
                 <p>Body Weight (kg)</p>
+                <span class="dial-min-max">136</span><span class="dial-min-max-divider">&nbsp;|&nbsp;</span><span class="dial-min-max">0&emsp;</span>
                 <div class="dial-shadow">
                     <div class="dial-container" id="body-weight">
                         <div class="dial"></div>
@@ -66,12 +68,24 @@
         </div>
         <div class="grid-item grid-item-5" id="grid-item-5">
             <div class="canvas-container" id="canvas-container">
-                <div id="button-wrapper">
-                    <input type="button" id="plus" value="+">
-                    <input type="button" id="minus" value="-">
-                  </div>
                 <canvas class="map" id="map"></canvas>
-                <script src="js/canvas.js"></script>
+                <div id="button-wrapper" class="zoom-button-wrapper">
+                    <input type="button" class="button zoom-button" id="minus" value="-">
+                    &ensp;Zoom&ensp;
+                    <input type="button" class="button zoom-button" id="plus" value="+">
+                    <button class="save-button button" id="save" onclick="downloadImage()">Save</button> 
+                    <script>
+                        function downloadImage() {
+                            var canvas = document.getElementById("map");
+                            image = canvas.toDataURL("image/png");
+                            var link = document.createElement('a');
+                            link.download = "my-image.png";
+                            link.href = image;
+                            link.click();
+                        }
+                    </script>
+                </div>
+                <script src="js/canvas.js"></script> 
             </div>
         </div>
         <div class="grid-item footer">
@@ -91,19 +105,6 @@
                         href="https://www.boisestate.edu/coen-cs/community/cs481-senior-design-project/">https://www.boisestate.edu/coen-cs/community/cs481-senior-design-project/</a>
                 </div>
             </div>
-        </div>
-        <div class="grid-item stretch-goal-buttons">
-            <button class="save-button button" id="save" onclick="downloadImage()">Save</button> 
-            <script>
-                function downloadImage() {
-                    var canvas = document.getElementById("map");
-                    image = canvas.toDataURL("image/png");
-                    var link = document.createElement('a');
-                    link.download = "my-image.png";
-                    link.href = image;
-                    link.click();
-                }
-            </script>
         </div>
     </div>
 </body>

--- a/src/stylesheets/style.css
+++ b/src/stylesheets/style.css
@@ -104,7 +104,7 @@ h2 {
 /* canvas section of the grid. holds the canvas-container */
 .grid-item-5 {
   grid-column: 6 / 11;
-  grid-row: 2 / 10;
+  grid-row: 2 / 11;
 }
 
 .footer {
@@ -112,11 +112,6 @@ h2 {
   grid-row: 10 / 11;
   text-align: left;
   padding: 0.5%;
-}
-
-.stretch-goal-buttons {
-  grid-column: 6 / 11;
-  grid-row: 10 / 11;
 }
 
 /* UPLOAD & DRAW BUTTONS */
@@ -164,6 +159,11 @@ input[type="file"]::file-selector-button:active {
   font-family: "Metropolis_Regular", sans-serif;
 }
 
+.draw-button-wrapper {
+  padding-left: 12%;
+  padding-top: 1%;
+}
+
 /* CANVAS */
 .map {
   background-color: white;
@@ -171,8 +171,8 @@ input[type="file"]::file-selector-button:active {
 }
 
 .canvas-container {
-  width: 97%;
-  height: 97%;
+  width: 95%;
+  height: 90%;
 }
 
 /* DIALS */
@@ -203,9 +203,9 @@ input[type="file"]::file-selector-button:active {
   left: 50%;
   top: 5%;
   transform: translateX(-50%);
-  border-radius: 15%;
-  width: 3%;
-  height: 25%;
+  border-radius: 25%;
+  width: 2%;
+  height: 20%;
   background: black;
 }
 
@@ -232,6 +232,17 @@ input[type="number"] {
   max-width: 10%;
   max-height: 10%;
   font-family: "Metropolis_Regular", sans-serif;
+}
+
+.dial-min-max {
+  margin-top: 0;
+  font-size: 0.75em;
+}
+
+.dial-min-max-divider {
+  margin-top: 0;
+  font-size: 1em;
+  font-family: "Metropolis_Bold", sans-serif;
 }
 
 /* HEAT MAP KEY */
@@ -285,13 +296,21 @@ input[type="number"] {
   color: #d64309;
 }
 
-/* SAVE BUTTON */
+/* SAVE & ZOOM BUTTONs */
 .save-button {
   float: right;
-  position: relative;
-  top: 5%;
-  right: 3%;
-  width: 12%;
-  height: 30%;
+  width: 10%;
+  padding: 0.5%;
+  margin-right: 0.2%;
   font-family: "Metropolis_Regular", sans-serif;
+}
+
+.zoom-button-wrapper {
+  padding-left: 12%;
+  padding-top: 1%;
+}
+
+.zoom-button {
+  padding: 0.25%;
+  width: 3%;
 }


### PR DESCRIPTION
Deleted the "stretch goal buttons" section of the layout grid and increased the size of the canvas section of the grid to replace the missing section. Moved the Zoom buttons below the canvas and labeled them, as well as moved the save button into the canvas section of the grid.