### PR TITLE
Dials now turn based on 360degrees/maxValue 

### DIFF
--- a/src/js/body-weight-dial.js
+++ b/src/js/body-weight-dial.js
@@ -61,11 +61,12 @@ function parameterDial2 (e) {
 // Dial rotation
 function rotate2 (e) {
   // final calculations for the mouse position
-  const result = Math.floor(parameterDial2(e) - 80)
+  parameterDial2(e)
+  let value2 = val2.value * (360/maxVal2)
 
   // rotate the dial based on final calculation - do not rotate further if value is at 0 or max
   if ((val2.value !== maxVal2) && (val2.value != 0)) { // eslint-disable-line
-    dial2.style.transform = 'rotate(' + result + 'deg)'
+    dial2.style.transform = 'rotate(' + value2 + 'deg)'
   }
 }
 

--- a/src/js/body-weight-dial.js
+++ b/src/js/body-weight-dial.js
@@ -62,7 +62,7 @@ function parameterDial2 (e) {
 function rotate2 (e) {
   // final calculations for the mouse position
   parameterDial2(e)
-  let value2 = val2.value * (360/maxVal2)
+  const value2 = val2.value * (360 / maxVal2)
 
   // rotate the dial based on final calculation - do not rotate further if value is at 0 or max
   if ((val2.value !== maxVal2) && (val2.value != 0)) { // eslint-disable-line

--- a/src/js/limb-alignment-dial.js
+++ b/src/js/limb-alignment-dial.js
@@ -68,12 +68,13 @@ function parameterDial1 (e) {
 // Dial rotation
 function rotate1 (e) {
   // final calculations for the mouse position
-  const result = Math.floor(parameterDial1(e) - 80)
+  parameterDial1(e)
+  let value1 = val1.value * (360/maxVal1)
 
   // rotate the dial based on final calculation - do not rotate further if value is at 0 or max
   if ((val1.value !== maxVal1) && (val1.value != 0)) { // eslint-disable-line
     // console.log(val1.value) // for testing
-    dial1.style.transform = 'rotate(' + result + 'deg)'
+    dial1.style.transform = 'rotate(' + value1 + 'deg)'
   }
 }
 

--- a/src/js/limb-alignment-dial.js
+++ b/src/js/limb-alignment-dial.js
@@ -69,7 +69,7 @@ function parameterDial1 (e) {
 function rotate1 (e) {
   // final calculations for the mouse position
   parameterDial1(e)
-  let value1 = val1.value * (360/maxVal1)
+  const value1 = val1.value * (360 / maxVal1)
 
   // rotate the dial based on final calculation - do not rotate further if value is at 0 or max
   if ((val1.value !== maxVal1) && (val1.value != 0)) { // eslint-disable-line


### PR DESCRIPTION
The dials will now only make one full rotation to go from 0 to their maximum value. If the user turns the dial quickly though, it will lag slightly behind their mouse.