### PR TITLE
Add final file checks

### DIFF
--- a/src/js/canvas.js
+++ b/src/js/canvas.js
@@ -68,7 +68,12 @@ window.onresize = function () {
 // Draws on canvas when draw button is pushed after selecting files
 draw.onclick = function () {
   draw.disabled = true
-  drawKnee(scale, translatePos)
+    // Let the user know if their geometry and results files don't match
+    if (!isBone && resultOutput.length != elements.length) {
+      alert('The number of elements in your geometry and results files do not match. Make sure you are using a corresponding set of files.')
+    } else{
+      drawKnee(scale, translatePos)
+    }
 }
 
 // Clears the canvas and draws the knee with data from files selected to canvas

--- a/src/js/canvas.js
+++ b/src/js/canvas.js
@@ -69,7 +69,7 @@ window.onresize = function () {
 draw.onclick = function () {
   draw.disabled = true
   // Let the user know if their geometry and results files don't match
-  if (!isBone && resultOutput.length != elements.length) { // eslint-disable-line
+  if ((!isBone && resultOutput.length != elements.length) && resultOutput.length !== 1) { // eslint-disable-line
     alert('The number of elements in your geometry and results files do not match. Make sure you are using a corresponding set of files.')
   } else {
     drawKnee(scale, translatePos)

--- a/src/js/canvas.js
+++ b/src/js/canvas.js
@@ -68,12 +68,12 @@ window.onresize = function () {
 // Draws on canvas when draw button is pushed after selecting files
 draw.onclick = function () {
   draw.disabled = true
-    // Let the user know if their geometry and results files don't match
-    if (!isBone && resultOutput.length != elements.length) {
-      alert('The number of elements in your geometry and results files do not match. Make sure you are using a corresponding set of files.')
-    } else{
-      drawKnee(scale, translatePos)
-    }
+  // Let the user know if their geometry and results files don't match
+  if (!isBone && resultOutput.length != elements.length) { // eslint-disable-line
+    alert('The number of elements in your geometry and results files do not match. Make sure you are using a corresponding set of files.')
+  } else {
+    drawKnee(scale, translatePos)
+  }
 }
 
 // Clears the canvas and draws the knee with data from files selected to canvas

--- a/src/js/parse-geometry.js
+++ b/src/js/parse-geometry.js
@@ -136,6 +136,7 @@ input.addEventListener('change', () => {
     console.log(nodes)
     console.log('FINAL ELEMENT ARRAY' + '\n')
     console.log(elements)
+    console.log('Total elements in geometry file: ' + elements.length + '\n')
   }
   // error catching
   reader.onerror = (e) => alert(e.target.error.name)

--- a/src/js/resultsParser.js
+++ b/src/js/resultsParser.js
@@ -97,6 +97,7 @@ resultInput.addEventListener('change', () => {
     lowestForce = resultLowestVal
     console.log(highestForce)
     console.log(lowestForce)
+    console.log('Total elements in results file: ' + resultOutput.length + '\n')
 
     heatmapKey(colorList) // eslint-disable-line
   }


### PR DESCRIPTION
Added a check in drawKnee() that will only let the user draw cartilage files with a matching number of elements in the geometry and results files. This will ensure that they are using files from the same data sets and for the same part of the knee at the same time. 